### PR TITLE
Add node-canvas font rendering utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "canvas": "^2.11.2",
+    "@fontsource/inter": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { renderTextImage } from '../../utils/canvasText';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const text = searchParams.get('text') || 'Hello World';
+  const buffer = renderTextImage(text, { width: 800, height: 200, fontSize: 64 });
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Length': buffer.length.toString(),
+    },
+  });
+}

--- a/src/app/utils/canvasText.ts
+++ b/src/app/utils/canvasText.ts
@@ -1,0 +1,37 @@
+import { createCanvas, registerFont } from 'canvas';
+
+// Register Inter font from @fontsource
+const interPath = require.resolve(
+  '@fontsource/inter/files/inter-latin-400-normal.ttf'
+);
+registerFont(interPath, { family: 'Inter', weight: 'normal', style: 'normal' });
+
+export interface TextOptions {
+  width?: number;
+  height?: number;
+  fontSize?: number;
+  color?: string;
+}
+
+export function renderTextImage(text: string, opts: TextOptions = {}): Buffer {
+  const width = opts.width ?? 1280;
+  const height = opts.height ?? 720;
+  const fontSize = opts.fontSize ?? 48;
+  const color = opts.color ?? '#ffffff';
+
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+
+  // Ensure anti-aliased text
+  ctx.antialias = 'subpixel';
+
+  ctx.fillStyle = 'transparent';
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = color;
+  ctx.font = `${fontSize}px "Inter"`;
+  ctx.textBaseline = 'top';
+  ctx.fillText(text, 0, 0);
+
+  return canvas.toBuffer('image/png');
+}

--- a/src/types/canvas.d.ts
+++ b/src/types/canvas.d.ts
@@ -1,0 +1,14 @@
+declare module 'canvas' {
+  interface Canvas {
+    getContext(contextId: '2d'): CanvasRenderingContext2D;
+    toBuffer(type?: 'image/png'): Buffer;
+  }
+  interface FontOptions {
+    family: string;
+    weight?: string;
+    style?: string;
+  }
+  function createCanvas(width: number, height: number): Canvas;
+  function registerFont(path: string, options: FontOptions): void;
+  export { createCanvas, registerFont };
+}


### PR DESCRIPTION
## Summary
- add Inter font to public assets
- install `canvas` and add `renderTextImage` helper
- expose `/api/preview` route that generates a PNG using the new font

## Testing
- `npm run lint`
- `npm run build` *(fails: can't fetch Google fonts; can't resolve `canvas`)*

------
https://chatgpt.com/codex/tasks/task_e_6879d33eb9c48332bf9af883fa3d44c7